### PR TITLE
Fix trivy-action version pin to v0.69.3

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -56,7 +56,7 @@ jobs:
         uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: "fs"
-          version: "v0.69.1"
+          version: "v0.69.3"
           ignore-unfixed: true
           format: "table"
           exit-code: "1"
@@ -65,7 +65,7 @@ jobs:
         uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
-          version: "v0.69.1"
+          version: "v0.69.3"
           format: "table"
           ignore-unfixed: true
           exit-code: "1"

--- a/.github/workflows/nightly-rescan.yml
+++ b/.github/workflows/nightly-rescan.yml
@@ -25,7 +25,7 @@ jobs:
         uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main
-          version: "v0.69.1"
+          version: "v0.69.3"
           format: "table"
           ignore-unfixed: true
           exit-code: "1"


### PR DESCRIPTION
## Summary

- Bump the `version:` input on every `aquasecurity/trivy-action@0.35.0` usage from `v0.69.1` to `v0.69.3`.
- Fixes the Trivy install failure on `docker-release` and `nightly-security-rescan` that has blocked every run on `main` since the action bump in ecaeb8a (2026-04-16).

## Why

`trivy-action@0.35.0` calls `aquasecurity/setup-trivy`, which runs `install.sh` from the current tip of `aquasecurity/trivy@main`. That script is written against the v0.69.3 release asset layout. With the stale `v0.69.1` pin, the script reports "found version: 0.69.1 for v0.69.1/Linux/64bit" and then exits 1 before producing a binary — deterministic every-run failure (runs 24523865903, 24596635912, 24620850157, 24648374101 all show the same stack).

`v0.69.3` is also the default `version` input that `trivy-action@0.35.0` was released with, so this realigns the action with the version it was tested against.

## Test plan

- [ ] `gh workflow run docker-release.yml --ref fix/ci-trivy-install` — run against this branch; Trivy fs + image scans pass, image push step is skipped (ref is not `refs/heads/main`).
- [ ] After merge, the next `docker-release` run on `main` goes green.
- [ ] Next scheduled `nightly-security-rescan` (03:17 UTC) goes green — or dispatched sooner via `gh workflow run nightly-rescan.yml`.